### PR TITLE
Add MRV token for Macroverse

### DIFF
--- a/config.js
+++ b/config.js
@@ -105,6 +105,7 @@ module.exports = {
     { addr: '0x4470bb87d77b963a013db939be332f927f2b992e', name: 'ADX', decimals: 4 },
     { addr: '0x621d78f2ef2fd937bfca696cabaf9a779f59b3ed', name: 'DRP', decimals: 2 },
     { addr: '0x725803315519de78d232265a8f1040f054e70b98', name: 'BET', decimals: 18 },
+    { addr: '0xab6cf87a50f17d7f5e1feaf81b6fe9ffbe8ebf84', name: 'MRV', decimals: 18 },
   ],
   defaultPair: { token: 'PLU', base: 'ETH' },
   pairs: [
@@ -166,6 +167,7 @@ module.exports = {
     { token: 'ADX', base: 'ETH' },
     { token: 'DRP', base: 'ETH' },
     { token: 'BET', base: 'ETH' },
+    { token: 'MRV', base: 'ETH' },
     { token: 'ETH', base: 'USD.DC' },
     { token: 'ETH', base: 'BTC.DC' },
   ],


### PR DESCRIPTION
If you do consider token pull requests, here is one for you. The Macroverse token, MRV, functions as a tokenized software license to use Macroverse, a procedurally-generated universe on the Ethereum blockchain.


The token is here: https://etherscan.io/token/0xAB6CF87a50F17d7F5E1FEaf81B6fE9FfBe8EBF84

The source is here: https://github.com/NovakDistributed/macroverse/blob/master/contracts/MRVToken.sol

Verification of the contract source on Etherscan is blocked pending updates in Etherscan to support the "runs" optimizer parameter used by Truffle; more information on that is here: https://github.com/trufflesuite/truffle/issues/456#issuecomment-312476458